### PR TITLE
Make knockout.clear module loader friendly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,8 +23,6 @@ module.exports = function(grunt) {
             grunt.file.mkdir('build/output');
             grunt.file.copy('lib/knockout.clear.js',
                             'build/output/knockout.clear.js');
-            grunt.file.copy('bower_components/knockout/dist/knockout.js',
-                            'build/output/knockout-latest.js');
         }
         return !this.errorCount;
     });

--- a/lib/knockout.clear.js
+++ b/lib/knockout.clear.js
@@ -1,5 +1,17 @@
-(function() {
+(function (factory) {
+    // Module systems magic dance.
 
+    if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+        // CommonJS or Node: hard-coded dependency on "knockout"
+        factory(require("knockout"), exports);
+    } else if (typeof define === "function" && define["amd"]) {
+        // AMD anonymous module with hard-coded dependency on "knockout"
+        define(["knockout", "exports"], factory);
+    } else {
+        // <script> tag: use the global `ko` object, attaching a `mapping` property
+        factory(ko, ko.clear = {});
+    }
+}(function ( ko, exports ) {
     if ((typeof ko === "undefined") ||
         (typeof ko.version !== "string") ||
         (parseFloat(ko.version.split("-")[0]) < 3.3)) {
@@ -124,4 +136,4 @@
         });
         return result;
     }
-}());
+}));

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
     "version": "0.1.2",
     "description": "Minimal utilities to make it easy to get KnockoutJS to clear up garbage automatically",
     "main": "lib/knockout.clear.js",
-    "dependencies": {},
+    "dependencies": {
+        "knockout": "~3.3.0"
+    },
     "devDependencies": {
-        "grunt": "^0.4.5"
+        "grunt": "^0.4.5",
+        "grunt-cli": "^0.1.13"
     },
     "scripts": {
-        "prepublish": "bower install && grunt",
+        "prepublish": "grunt",
         "test": "node spec/runner.node.js"
     },
     "repository": {

--- a/spec/lib/loadDependencies.js
+++ b/spec/lib/loadDependencies.js
@@ -41,6 +41,6 @@
         }
     }
 
-    jasmine.addScriptReference("../build/output/knockout-latest.js");
+    jasmine.addScriptReference("../node_modules/knockout/build/output/knockout-latest.js");
     jasmine.addScriptReference("../build/output/knockout.clear.js");
 })();

--- a/spec/runner.node.js
+++ b/spec/runner.node.js
@@ -25,7 +25,7 @@ if (process.argv.length > 2 && process.argv[2] == '--source') {
     };
     require('../build/fragments/source-references');
 } else {
-    global.ko = require('../build/output/knockout-latest.js');
+    global.ko = require('knockout');
 }
 
 require('../build/output/knockout.clear.js');


### PR DESCRIPTION
Much like the knockout-validation contrib extension, knockout.clear should detect if a module loader is in place and use that instead of assuming ko is a global object.

I've mostly ripped the module-related code from knockout-validation (1st commit). The 2nd commit is to make the tests work again.
